### PR TITLE
Fix Breadcrumb NavigationDuplicated and pathToRegexp error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ yarn-error.log*
 # Editor directories and files
 .idea
 .vscode
+.history
+.ionide
 *.suo
 *.ntvs*
 *.njsproj

--- a/src/components/Breadcrumb/index.vue
+++ b/src/components/Breadcrumb/index.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script lang="ts">
-import pathToRegexp from 'path-to-regexp'
+import { compile } from 'path-to-regexp'
 import { Component, Vue, Watch } from 'vue-property-decorator'
 import { RouteRecord, Route } from 'vue-router'
 
@@ -67,17 +67,19 @@ export default class extends Vue {
   private pathCompile(path: string) {
     // To solve this problem https://github.com/PanJiaChen/vue-element-admin/issues/561
     const { params } = this.$route
-    const toPath = pathToRegexp.compile(path)
+    const toPath = compile(path)
     return toPath(params)
   }
 
   private handleLink(item: any) {
+    // Throw Error "NavigationDuplicated"
+    // https://github.com/vuejs/vue-router/issues/2872
     const { redirect, path } = item
     if (redirect) {
-      this.$router.push(redirect)
+      this.$router.push(redirect).catch(_err => {})
       return
     }
-    this.$router.push(this.pathCompile(path))
+    this.$router.push(this.pathCompile(path)).catch(_err => {})
   }
 }
 </script>

--- a/src/components/DraggableSelect/index.vue
+++ b/src/components/DraggableSelect/index.vue
@@ -41,7 +41,7 @@ export default class extends Vue {
     const el = draggableSelect.$el.querySelectorAll('.el-select__tags > span')[0] as HTMLElement
     this.sortable = Sortable.create(el, {
       ghostClass: 'sortable-ghost', // Class name for the drop placeholder
-      onEnd: evt => {
+      onEnd: (evt: any) => {
         if (typeof (evt.oldIndex) !== 'undefined' && typeof (evt.newIndex) !== 'undefined') {
           const targetRow = this.value.splice(evt.oldIndex, 1)[0]
           this.value.splice(evt.newIndex, 0, targetRow)

--- a/src/views/table/draggable-table.vue
+++ b/src/views/table/draggable-table.vue
@@ -158,7 +158,7 @@ export default class extends Vue {
     const el = (this.$refs.draggableTable as Vue).$el.querySelectorAll('.el-table__body-wrapper > table > tbody')[0] as HTMLElement
     this.sortable = Sortable.create(el, {
       ghostClass: 'sortable-ghost', // Class name for the drop placeholder
-      onEnd: evt => {
+      onEnd: (evt: any) => {
         if (typeof (evt.oldIndex) !== 'undefined' && typeof (evt.newIndex) !== 'undefined') {
           const targetRow = this.list.splice(evt.oldIndex, 1)[0]
           this.list.splice(evt.newIndex, 0, targetRow)


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**More information:**

Fix the `components/Breadcrumb/index.Vue`'s bug and fix lint of implicit 'any' type

1. `this.$router.push(redirect)` will throw `NavigationDuplicated` when push the same route.
2. In `import pathToRegexp from 'path-to-regexp'` , `pathToRegexp` is undefined.