### PR TITLE
Fix: Remove fibers so it can be built with node 16+

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.3.1",
     "eslint-plugin-vue": "^7.8.0",
-    "fibers": "^5.0.0",
     "lint-staged": "^10.5.4",
     "sass": "^1.32.8",
     "sass-loader": "^10.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4483,11 +4483,6 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
-detect-libc@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
-
 detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
@@ -5439,13 +5434,6 @@ fflate@^0.3.8:
   version "0.3.11"
   resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.3.11.tgz#2c440d7180fdeb819e64898d8858af327b042a5d"
   integrity sha512-Rr5QlUeGN1mbOHlaqcSYMKVpPbgLy0AWT/W0EHxA6NGI12yO1jpoui2zBBvU2G824ltM6Ut8BFgfHSBGfkmS0A==
-
-fibers@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/fibers/-/fibers-5.0.0.tgz#3a60e0695b3ee5f6db94e62726716fa7a59acc41"
-  integrity sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==
-  dependencies:
-    detect-libc "^1.0.3"
 
 figgy-pudding@^3.5.1:
   version "3.5.2"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/Armour/vue-typescript-admin-template/blob/master/.github/CONTRIBUTING.md#submitting-a-pull-request
-->

<!-- PULL REQUEST TEMPLATE -->

**Make sure the PR fulfills these requirements:**

- When resolving a specific issue, make sure it's referenced in the PR's title (e.g. `Closes #xxx[,#xxx]`, where "xxx" is the issue number)

- If adding a **new feature**, the PR's description includes: A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

- If this PR introduce a **breaking change**, please describe the impact and migration path for existing applications

**What kind of change does this PR introduce?**

Remove [node-fibers](https://github.com/laverdet/node-fibers), so this project can be built with Node 16+.

**More information:**

According to [node-fibers](https://github.com/laverdet/node-fibers)'s readme, that project is obsolete, and will not work on Node 16+.

Since `fibers` [is an optional dependency](https://cli.vuejs.org/guide/css.html#pre-processors), it can be safely removed. The performance will be dropped, but at least you can keep using the latest LTS version of Node.js now.