### PR TITLE
Refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -85,8 +85,8 @@ export const toggleClass = (ele: HTMLElement, className: string) => {
     classString += '' + className
   } else {
     classString =
-      classString.substr(0, nameIndex) +
-      classString.substr(nameIndex + className.length)
+      classString.slice(0, nameIndex) +
+      classString.slice(nameIndex + className.length)
   }
   ele.className = classString
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- refactor

**More information:**

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.